### PR TITLE
Add Flutter project skeleton

### DIFF
--- a/bit_flip/.gitignore
+++ b/bit_flip/.gitignore
@@ -1,0 +1,21 @@
+# Flutter/Dart/Pub related
+.dart_tool/
+.packages
+build/
+
+# Visual Studio Code
+.vscode/
+
+# IntelliJ/Android Studio
+*.iml
+.idea/
+
+# iOS
+ios/Pods/
+
+# Android
+**/gradle-wrapper.jar
+**/gradle-wrapper.properties
+**/gradlew
+**/gradlew.bat
+**/local.properties

--- a/bit_flip/lib/main.dart
+++ b/bit_flip/lib/main.dart
@@ -1,0 +1,27 @@
+import 'package:flutter/material.dart';
+
+void main() => runApp(const MyApp());
+
+class MyApp extends StatelessWidget {
+  const MyApp({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    return MaterialApp(
+      title: 'Bit Flip',
+      theme: ThemeData(primarySwatch: Colors.blue),
+      home: const MyHomePage(),
+    );
+  }
+}
+
+class MyHomePage extends StatelessWidget {
+  const MyHomePage({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    return const Scaffold(
+      body: Center(child: Text('Hello, Bit Flip!')),
+    );
+  }
+}

--- a/bit_flip/pubspec.yaml
+++ b/bit_flip/pubspec.yaml
@@ -1,0 +1,22 @@
+name: bit_flip
+description: A new Flutter project.
+publish_to: 'none'
+version: 0.1.0
+
+environment:
+  sdk: '>=3.0.0 <4.0.0'
+
+dependencies:
+  flutter:
+    sdk: flutter
+  flame: ^1.0.0
+  shared_preferences: ^2.0.0
+  share_plus: ^7.0.0
+
+dev_dependencies:
+  flutter_test:
+    sdk: flutter
+  flutter_lints: ^3.0.0
+
+flutter:
+  uses-material-design: true

--- a/bit_flip/test/widget_test.dart
+++ b/bit_flip/test/widget_test.dart
@@ -1,0 +1,7 @@
+import 'package:flutter_test/flutter_test.dart';
+
+void main() {
+  testWidgets('smoke test', (WidgetTester tester) async {
+    // TODO: add widget tests
+  });
+}


### PR DESCRIPTION
## Summary
- add a minimal Flutter project skeleton `bit_flip`
- include dependencies in `pubspec.yaml`

## Testing
- `../flutter/bin/flutter pub get --directory bit_flip` *(fails: CONNECT tunnel failed 403)*

------
https://chatgpt.com/codex/tasks/task_e_6840946613848331bfec29e2dba9ca26